### PR TITLE
Explicitly require 'forwardable' (jruby / mri2.x compat)

### DIFF
--- a/lib/dot_properties.rb
+++ b/lib/dot_properties.rb
@@ -1,4 +1,5 @@
 require "dot_properties/version"
+require 'forwardable'
 
 class DotProperties
   extend Forwardable


### PR DESCRIPTION
Some (all?) versions of jruby and MRI 2.x don't automatically have 'forwardable' available (same is true of stdio, for example). This pulls it in explicitly.
