### PR TITLE
Fix typo in gem name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Reads and writes [Java .properties files](http://en.wikipedia.org/wiki/.properti
 
 Add this line to your application's Gemfile:
 
-    gem 'dot_properties'
+    gem 'dot-properties'
 
 And then execute:
 


### PR DESCRIPTION
The gem name in the decsription in the README should be 'dot-properties' (notice the dash character instead of the low line)