### PR TITLE
Update bundler version (dependant alert)

### DIFF
--- a/dot-properties.gemspec
+++ b/dot-properties.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_dependency "bundler", ">= 2.2.33"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rdoc", ">= 2.4.2"


### PR DESCRIPTION
I got a dependant alert (CVE-2019-3881) for my fork and saw that the original isn't updated (yet).